### PR TITLE
optimizing for the 3.5" pi lcd:

### DIFF
--- a/src/clj/ccclock/css.clj
+++ b/src/clj/ccclock/css.clj
@@ -28,7 +28,7 @@
     :padding-top "0vw"}]
 
   [:.temp-display :.temp
-   {:font-size "16vw"
+   {:font-size "16.5vw"
     :padding-bottom "1vw"}]
 
   [:.temp-display :.hi-low

--- a/src/clj/ccclock/css.clj
+++ b/src/clj/ccclock/css.clj
@@ -13,12 +13,12 @@
     :color "#6A5ACD"}]
 
   [:#app
-   {:margin "3vw"
-    :padding "3vw"}]
+   {:margin "0.5vw"
+    :padding "0.5vw"}]
 
   [:.time-display
-   {:font-size "20vw"
-    :width "66%"
+   {:font-size "23vw"
+    :width "70%"
     :float "right"}]
 
   [:.temp-display
@@ -26,15 +26,15 @@
     :float "left"}]
 
   [:.temp-display :.temp
-   {:font-size "12vw"}]
+   {:font-size "16vw"}]
 
   [:.temp-display :.hi-low
-   {:font-size "6vw"}]
+   {:font-size "7vw"}]
 
   [:.cond-display
-   {:font-size "16vw"
+   {:font-size "20vw"
     :text-align "center"
     :letter-spacing "1vw"
-    :padding-top "6vw"
+    :padding-top "4vw"
     :clear "both"
     :width "100%"}])

--- a/src/clj/ccclock/css.clj
+++ b/src/clj/ccclock/css.clj
@@ -35,7 +35,7 @@
    {:font-size "7vw"}]
 
   [:.cond-display
-   {:font-size "20vw"
+   {:font-size "19vw"
     :text-align "center"
     :letter-spacing "1vw"
     :padding-top "6vw"

--- a/src/clj/ccclock/css.clj
+++ b/src/clj/ccclock/css.clj
@@ -14,7 +14,7 @@
 
   [:#app
    {:margin "0.5vw"
-    :margin-top "2vw"
+    :margin-top "4vw"
     :padding "0.5vw"}]
 
   [:.time-display
@@ -25,7 +25,7 @@
   [:.temp-display
    {:width "20%"
     :float "left"
-    :padding-top "2vw"}]
+    :padding-top "0vw"}]
 
   [:.temp-display :.temp
    {:font-size "16vw"
@@ -38,6 +38,6 @@
    {:font-size "20vw"
     :text-align "center"
     :letter-spacing "1vw"
-    :padding-top "2vw"
+    :padding-top "6vw"
     :clear "both"
     :width "100%"}])

--- a/src/clj/ccclock/css.clj
+++ b/src/clj/ccclock/css.clj
@@ -14,6 +14,7 @@
 
   [:#app
    {:margin "0.5vw"
+    :margin-top "2vw"
     :padding "0.5vw"}]
 
   [:.time-display
@@ -23,10 +24,12 @@
 
   [:.temp-display
    {:width "20%"
-    :float "left"}]
+    :float "left"
+    :padding-top "2vw"}]
 
   [:.temp-display :.temp
-   {:font-size "16vw"}]
+   {:font-size "16vw"
+    :padding-bottom "1vw"}]
 
   [:.temp-display :.hi-low
    {:font-size "7vw"}]
@@ -35,6 +38,6 @@
    {:font-size "20vw"
     :text-align "center"
     :letter-spacing "1vw"
-    :padding-top "4vw"
+    :padding-top "2vw"
     :clear "both"
     :width "100%"}])

--- a/src/cljs/ccclock/views.cljs
+++ b/src/cljs/ccclock/views.cljs
@@ -9,7 +9,8 @@
   (let [time-raw      @(re-frame/subscribe [::subs/time])
         time-segments (clojure.string/split (.toTimeString time-raw) ":")
         hour->int     (js/parseInt (first time-segments))
-        hour          (if (> hour->int 12) (- hour->int 12) hour->int)
+        hour-12h      (if (>= hour->int 13) (- hour->int 12) hour->int)
+        hour          (if (<= hour-12h 9) (str "0" hour-12h) hour-12h)
         minutes       (second time-segments)
         clock-time    (str hour ":" minutes)]
     clock-time))


### PR DESCRIPTION
- reducing padding and margins
- increase size of key at a glance elements
- attempting to not make spacing too tight